### PR TITLE
Upgrade key_vault azurerm provider requirement

### DIFF
--- a/modules/key_vault/main.tf
+++ b/modules/key_vault/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">=0.14.0"
 
   required_providers {
-    azurerm = "=2.37.0"
+    azurerm = "=2.71.0"
   }
 
   backend "azurerm" {}


### PR DESCRIPTION
#66 heeft `soft_delete_enabled` weggehaald, omdat die niet meer ondersteund is. Dat is wel zo, maar pas versie v2.42 van de `azurerm` provider die was ingesteld, waardoor je alsnog foutmeldingen kreeg dat `soft_delete_enabled` ontbreekt.

Provider staat nu op de laatste versie, daar werkt alles naar behoren.