### PR TITLE
Fix connection_string block in public app service

### DIFF
--- a/modules/app_service_public/main.tf
+++ b/modules/app_service_public/main.tf
@@ -32,7 +32,14 @@ resource "azurerm_app_service" "app_service" {
 
   app_settings = var.app_settings
 
-  connection_string = var.connection_string
+  dynamic "connection_string" {
+    for_each = var.connection_strings
+    content {
+      name = each.value.name
+      type = each.value.type
+      value = each.value.value
+    }
+  }
 
   identity {
     type = "SystemAssigned"

--- a/modules/app_service_public/main.tf
+++ b/modules/app_service_public/main.tf
@@ -35,8 +35,8 @@ resource "azurerm_app_service" "app_service" {
   dynamic "connection_string" {
     for_each = var.connection_strings
     content {
-      name = each.value.name
-      type = each.value.type
+      name  = each.value.name
+      type  = each.value.type
       value = each.value.value
     }
   }

--- a/modules/app_service_public/variables.tf
+++ b/modules/app_service_public/variables.tf
@@ -29,14 +29,15 @@ variable "app_settings" {
   default     = {}
 }
 
-variable "connection_string" {
-  type = object({
-    name  = string,
-    type  = string,
-    value = string
-  })
-  description = "A connection string used by the app service."
-  default     = null
+variable "connection_strings" {
+  type = set(
+    object({
+      name  = string,
+      type  = string,
+      value = string
+    }))
+  description = "A list of connection strings used by the app service."
+  default     = []
 }
 
 variable "linux_fx_version" {


### PR DESCRIPTION
`connection_string` is a block, which cannot be assigned a value. It's also possible to have multiple connection strings, so this is now also possible.