### PR TITLE
Mark storage-blob-url as sensitive

### DIFF
--- a/modules/storage_blob/outputs.tf
+++ b/modules/storage_blob/outputs.tf
@@ -1,3 +1,4 @@
 output "storage_blob_url" {
   value = "https://${azurerm_storage_blob.storage_blob.storage_account_name}.blob.core.windows.net/${azurerm_storage_blob.storage_blob.storage_container_name}/${azurerm_storage_blob.storage_blob.name}${data.azurerm_storage_account_sas.sas_token.sas}"
+  sensitive = true
 }


### PR DESCRIPTION
Fixes the following error:

```
│ Error: Output refers to sensitive values
│
│   on outputs.tf line 1:
│    1: output "storage_blob_url" {
│
│ To reduce the risk of accidentally exporting sensitive data that was
│ intended to be only internal, Terraform requires that any root module
│ output containing sensitive data be explicitly marked as sensitive, to
│ confirm your intent.
│
│ If you do intend to export this data, annotate the output value as
│ sensitive by adding the following argument:
│     sensitive = true
```